### PR TITLE
Fixed double-slash syntax for comment

### DIFF
--- a/vector/swap.md
+++ b/vector/swap.md
@@ -8,7 +8,7 @@
     std::vector<int> vector1 = {1,2,3};
     std::vector<int> vector2 = {4,5,6,6};
 
-    /Function to swap the vectors
+    //Function to swap the vectors
     vector1.swap(vector2);
 
 ```


### PR DESCRIPTION
The code snippet for swap.md had a comment that was missing a forward slash.