### PR TITLE
Missing Display in for_each.md

### DIFF
--- a/algorithm/for_each.md
+++ b/algorithm/for_each.md
@@ -4,7 +4,7 @@
  
 **Example :**
 ```cpp
-       class {
+       class Display{
         public: 
             void operator() (int i){ 
             std::cout << i << " ";


### PR DESCRIPTION
The class name(`Display`) was missing in the Markdown file.