### PR TITLE
fix sample code links(snippets) in algorithm/ and vector/

### DIFF
--- a/algorithm/copy.md
+++ b/algorithm/copy.md
@@ -15,5 +15,5 @@
         std::cout << value << " "; 
     }
 ```
-**[See Sample code](snippets/algorithm/copy.cpp)**
+**[See Sample code](../snippets/algorithm/copy.cpp)**
 **[Run Code](https://rextester.com/DPG88459)**

--- a/algorithm/copy_backward.md
+++ b/algorithm/copy_backward.md
@@ -17,5 +17,5 @@ Elements are copied in reverse order (last element is copied first), but the rel
         std::cout << value << " "; 
     }
 ```
-**[See Sample code](snippets/algorithm/copy_backward.cpp)**
+**[See Sample code](../snippets/algorithm/copy_backward.cpp)**
 **[Run Code](https://rextester.com/INZK42877)**

--- a/algorithm/copy_if.md
+++ b/algorithm/copy_if.md
@@ -19,5 +19,5 @@
         std::cout << value << " "; 
     }
 ```
-**[See Sample code](snippets/algorithm/copy_if.cpp)**
+**[See Sample code](../snippets/algorithm/copy_if.cpp)**
 **[Run Code](https://rextester.com/OMC23438)**

--- a/algorithm/copy_n.md
+++ b/algorithm/copy_n.md
@@ -15,5 +15,5 @@
         std::cout << value << " "; 
     }
 ```
-**[See Sample code](snippets/algorithm/copy_n.cpp)**
+**[See Sample code](../snippets/algorithm/copy_n.cpp)**
 **[Run Code](https://rextester.com/GXR34835)**

--- a/algorithm/equal_range.md
+++ b/algorithm/equal_range.md
@@ -17,5 +17,5 @@
     }
 
 ```
-**[See Sample code](snippets/algorithm/equal_range.cpp)**
+**[See Sample code](../snippets/algorithm/equal_range.cpp)**
 **[Run Code](https://rextester.com/ZYGGE30271)**

--- a/algorithm/includes.md
+++ b/algorithm/includes.md
@@ -24,5 +24,5 @@
     std::cout << " v1 contains v3? " << v1ContainsV3 << std::endl;
    
 ```
-**[See Sample code](snippets/algorithm/includes.cpp)**
+**[See Sample code](../snippets/algorithm/includes.cpp)**
 **[Run Code](https://rextester.com/MMPQ67900)**

--- a/algorithm/lower_bound.md
+++ b/algorithm/lower_bound.md
@@ -13,5 +13,5 @@
     std::cout << "The lower bound element is " << *lowerBoundIt << '\n';
 
 ```
-**[See Sample code](snippets/algorithm/lower_bound.cpp)**
+**[See Sample code](../snippets/algorithm/lower_bound.cpp)**
 **[Run Code](https://rextester.com/KFK22059)**

--- a/algorithm/max.md
+++ b/algorithm/max.md
@@ -9,5 +9,5 @@
     // prints 7
     std::cout << smallest << " "; 
 ```
-**[See Sample code](snippets/algorithm/max.cpp)**
+**[See Sample code](../snippets/algorithm/max.cpp)**
 **[Run Code](https://rextester.com/RCHUQA23545)**

--- a/algorithm/max_element.md
+++ b/algorithm/max_element.md
@@ -11,5 +11,5 @@
     std::cout << "The greatest element is " << *greatestIt << '\n';
 
 ```
-**[See Sample code](snippets/algorithm/max_element.cpp)**
+**[See Sample code](../snippets/algorithm/max_element.cpp)**
 **[Run Code](https://rextester.com/MYCU8700)**

--- a/algorithm/merge.md
+++ b/algorithm/merge.md
@@ -22,5 +22,5 @@
         std::cout << value << " "; 
     }
 ```
-**[See Sample code](snippets/algorithm/merge.cpp)**
+**[See Sample code](../snippets/algorithm/merge.cpp)**
 **[Run Code](https://rextester.com/TPXUS57604)**

--- a/algorithm/min.md
+++ b/algorithm/min.md
@@ -9,5 +9,5 @@
     // prints 3
     std::cout << smallest << " "; 
 ```
-**[See Sample code](snippets/algorithm/min.cpp)**
+**[See Sample code](../snippets/algorithm/min.cpp)**
 **[Run Code](https://rextester.com/RCHUQA23545)**

--- a/algorithm/min_element.md
+++ b/algorithm/min_element.md
@@ -11,5 +11,5 @@
     std::cout << "The smallest element is " << *smallestIt << '\n';
 
 ```
-**[See Sample code](snippets/algorithm/min_element.cpp)**
+**[See Sample code](../snippets/algorithm/min_element.cpp)**
 **[Run Code](https://rextester.com/ZVBA46979)**

--- a/algorithm/minmax.md
+++ b/algorithm/minmax.md
@@ -17,5 +17,5 @@
                  " Max is " << minMax2.second << std::endl;
 
 ```
-**[See Sample code](snippets/algorithm/minmax.cpp)**
+**[See Sample code](../snippets/algorithm/minmax.cpp)**
 **[Run Code](https://rextester.com/AYBQP34022)**

--- a/algorithm/minmax_element.md
+++ b/algorithm/minmax_element.md
@@ -12,5 +12,5 @@
                  " Max is " << *minMaxPair.second << std::endl;
 
 ```
-**[See Sample code](snippets/algorithm/minmax_element.cpp)**
+**[See Sample code](../snippets/algorithm/minmax_element.cpp)**
 **[Run Code](https://rextester.com/NSPL12489)**

--- a/algorithm/set_difference.md
+++ b/algorithm/set_difference.md
@@ -28,5 +28,5 @@
     }
    
 ```
-**[See Sample code](snippets/algorithm/set_difference.cpp)**
+**[See Sample code](../snippets/algorithm/set_difference.cpp)**
 **[Run Code](https://rextester.com/QWJK9322)**

--- a/algorithm/set_intersection.md
+++ b/algorithm/set_intersection.md
@@ -28,5 +28,5 @@
     }
    
 ```
-**[See Sample code](snippets/algorithm/set_intersecton.cpp)**
+**[See Sample code](../snippets/algorithm/set_intersection.cpp)**
 **[Run Code](https://rextester.com/LEHJ94279)**

--- a/algorithm/set_union.md
+++ b/algorithm/set_union.md
@@ -28,5 +28,5 @@
     }
    
 ```
-**[See Sample code](snippets/algorithm/set_union.cpp)**
+**[See Sample code](../snippets/algorithm/set_union.cpp)**
 **[Run Code](https://rextester.com/LFXB93097)**

--- a/vector/assign.md
+++ b/vector/assign.md
@@ -29,5 +29,5 @@ Two variations:
     example.assign(3, 0);
     // example is now: { 0, 0, 0 }
 ```
-**[See Sample code](snippets/vector/assign.cpp)**
+**[See Sample code](../snippets/vector/assign.cpp)**
 **[Run Code](https://rextester.com/LWBW83885)**

--- a/vector/erase.md
+++ b/vector/erase.md
@@ -28,5 +28,5 @@ Two variations:
     vector2.erase( std::remove(vector2.begin(),vector2.end(),valueToRemove),vector2.end());
 
 ```
-**[See Sample code](snippets/vector/erase.cpp)**
+**[See Sample code](../snippets/vector/erase.cpp)**
 **[Run Code](https://rextester.com/XWYI46957)**

--- a/vector/push_back.md
+++ b/vector/push_back.md
@@ -12,5 +12,5 @@
     vector1.push_back(2);
 
 ```
-**[See Sample code](snippets/vector/push_back.cpp)**
+**[See Sample code](../snippets/vector/push_back.cpp)**
 **[Run Code](https://rextester.com/JBQCG9959)**

--- a/vector/swap.md
+++ b/vector/swap.md
@@ -12,5 +12,5 @@
     vector1.swap(vector2);
 
 ```
-**[See Sample code](snippets/vector/swap.cpp)**
+**[See Sample code](../snippets/vector/swap.cpp)**
 **[Run Code](https://rextester.com/PNR78595)**


### PR DESCRIPTION
... also one spelling error made in "intersection"(vs. intersecton)

They nearly all had a missing `../` in the URL which redirected it to `master/algorithm/snippets` or `master/vector/snippets`. 