### PR TITLE
Add missing references to lower bound implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@
 <li><a href="set/emplace.md"><code>emplace</code></a></li>
 <li><a href="set/empty.md"><code>empty</code></a></li>
 <li><a href="set/insert.md"><code>insert</code></a></li>
+<li><a href="set/lower_bound.md"><code>lower_bound</code></a></li>
 <li><a href="set/size.md"><code>size</code></a></li>
 
 </ol>

--- a/set/README.md
+++ b/set/README.md
@@ -5,6 +5,7 @@
 :heavy_check_mark: [emplace](emplace.md)  
 :heavy_check_mark: [empty](empty.md)  
 :heavy_check_mark: [insert](insert.md)  
+:heavy_check_mark: [lower_bound](lower_bound.md)  
 :heavy_check_mark: [size](size.md)  
 :x: cbegin  
 :x: cend  
@@ -17,7 +18,6 @@
 :x: erase  
 :x: extract  
 :x: find  
-:x: lower_bound  
 :x: max_size  
 :x: merge  
 :x: rbegin  

--- a/set/todo.txt
+++ b/set/todo.txt
@@ -14,5 +14,4 @@ merge
 find
 contains
 equal_range
-lower_bound
 upper_bound


### PR DESCRIPTION
Fixes #324

Adds references for the lower_bound file on the README files.