### PR TITLE
transform_reduce.md

### DIFF
--- a/algorithm/transform_reduce.md
+++ b/algorithm/transform_reduce.md
@@ -1,0 +1,27 @@
+
+# transform_reduce
+
+**Description :**  Applies a functor, then reduces. The default functor is multiplication. Available in C++17 and above.
+
+
+**Example** :
+
+```cpp   
+int main()
+{
+  std::vector<int> arr{1, 2, 3, 4, 5};
+  int result;
+ 
+ // the functor here squares each element
+ // addition is used to reduce
+  result = std17::transform_reduce(arr.begin(),
+                                   arr.end()  ,
+                                   0                    ,
+                                  [](auto a, auto b) {return a + b;},
+                                  [](auto a        ) {return a * a;});
+  // finds sum of squares of arr
+  std::cout << result << std::endl;
+  return 0;
+}
+```
+**[Run Code](https://rextester.com/YPMMS86271)**

--- a/algorithm/transform_reduce.md
+++ b/algorithm/transform_reduce.md
@@ -1,8 +1,6 @@
-
 # transform_reduce
 
 **Description :**  Applies a functor, then reduces. The default functor is multiplication. Available in C++17 and above.
-
 
 **Example** :
 


### PR DESCRIPTION
rextester only supports g++ 5.4.0, so the actual code in the run code link will have a work around to help run the algorithm that requires c++17 or higher.