### PR TITLE
fixed 404 link in vectors

### DIFF
--- a/vector/README.md
+++ b/vector/README.md
@@ -1,5 +1,5 @@
 # `<vector>`
-:heavy_check_mark: [Vector](Vector.md)  
+:heavy_check_mark: [Vector](vector.md)  
 :heavy_check_mark: [assign](assign.md)  
 :heavy_check_mark: [at](at.md)  
 :heavy_check_mark: [back](back.md)  


### PR DESCRIPTION
In the [vectors](https://github.com/Bhupesh-V/30-seconds-of-cpp/tree/master/vector) folder, clicking on the Vector link will lead to a 404 page. The cpp file is named vector, while the link is to Vector