### PR TITLE
Fix typo in priority_queue/size.md comment.

### DIFF
--- a/priority_queue/size.md
+++ b/priority_queue/size.md
@@ -11,7 +11,7 @@
     my.push(10);
     my.push(4);
 
-    // returns the first value of the queue(largest)
+    // Prints the size of the priority_queue.
     std::cout << my.size();
 ```
 


### PR DESCRIPTION
<!-- short description of your changes -->
This PR... fixes the typo at line 14 in file priority_queue/size.md.

<!-- Add issue no which corresponds to this PR -->

## Changes
<!-- go verbose here & explain what you changed -->
- I made a descriptive comment for the size method.

## Checklist
- [ ] I have read CONTRIBUTING guidelines.
- [x] This is a typo fix.
- [ ] I am not updating any `todo.txt` files.
