### PR TITLE
Add information for unordered_map::extract

### DIFF
--- a/snippets/unordered_map/extract.cpp
+++ b/snippets/unordered_map/extract.cpp
@@ -1,0 +1,37 @@
+//Demonstrates extract()
+#include <iostream>
+#include <unordered_map>
+
+int main(){
+    std::unordered_map<int, char> mymap;
+
+    //inserting in to unordered_map with O(1) time on average
+    mymap.insert({1, 'A'});
+    mymap.insert({2, 'b'});
+    mymap.insert({3, 'c'});
+
+    //print elements of  unordered_map before extract
+    std::cout << "Before extraction \n";
+    for (auto it = mymap.begin(); it != mymap.end(); ++it){
+        std::cout << it->first << " = "<< it->second << '\n';
+    }
+
+    //extract node from map using key
+    auto nodeHandle = mymap.extract(1);
+
+    //Print elements of unordered_map after extract
+    std::cout << "After extraction \n";
+    for (auto it = mymap.begin(); it != mymap.end(); ++it){
+        std::cout << it->first << " = "<< it->second << '\n';
+    }
+
+    //Modify key of node, then insert
+    nodeHandle.key() = 4;
+    mymap.insert(move(nodeHandle));
+
+    //Print after changing key
+    std::cout << "After key-change \n";
+    for (auto it = mymap.begin(); it != mymap.end(); ++it){
+        std::cout << it->first << " = "<< it->second << '\n';
+    }
+}

--- a/unordered_map/extract.md
+++ b/unordered_map/extract.md
@@ -1,0 +1,43 @@
+# extract
+**Description: ** This function is used to remove a node (a key and its associated value) from an `unordered_map`. Pointers and references to the extracted node should still work properly, and order within the `unordered_map` is unchanged. Note that pointers and references can only be used when the node is re-inserted into an `unordered_map` or `map`.
+
+**Example** :
+```cpp
+//Demonstrates extract()
+#include <iostream>
+#include <unordered_map>
+
+int main(){
+    std::unordered_map<int, char> mymap;
+
+    //inserting in to unordered_map with O(1) time on average
+    mymap.insert({1, 'A'});
+    mymap.insert({2, 'b'});
+    mymap.insert({3, 'c'});
+
+    //print elements of  unordered_map before extract
+    std::cout << "Before extraction \n";
+    for (auto it = mymap.begin(); it != mymap.end(); ++it){
+        std::cout << it->first << " = "<< it->second << '\n';
+    }
+
+    //extract node from map using key
+    auto nodeHandle = mymap.extract(1);
+
+    //Print elements of unordered_map after extract
+    std::cout << "After extraction \n";
+    for (auto it = mymap.begin(); it != mymap.end(); ++it){
+        std::cout << it->first << " = "<< it->second << '\n';
+    }
+
+    //Modify key of node, then insert
+    nodeHandle.key() = 4;
+    mymap.insert(move(nodeHandle));
+
+    //Print after changing key
+    std::cout << "After key-change \n";
+    for (auto it = mymap.begin(); it != mymap.end(); ++it){
+        std::cout << it->first << " = "<< it->second << '\n';
+    }
+}
+```


### PR DESCRIPTION
<!-- short description of your changes -->
This PR creates a markdown file for the `unordered_map`'s `extract` method. It also contains the same code snippets in the `snippets` folder, that both compiles correctly and performs as expected.

## Changes
<!-- go verbose here & explain what you changed -->
- Implemented and described the use of the `extract` method for `unordered_map` in a markdown file, and demonstrates a use-case.
- Copied the implementation from the aforementioned markdown file into a compile-able C++ file in the `snippets` directory.

## Checklist
- [x] I have read CONTRIBUTING guidelines.
- [x] This is a typo fix.
- [x] I am not updating any `todo.txt` files.
