### PR TITLE
Fix typo in std::is_heap (from <algorithm>)

### DIFF
--- a/algorithm/is_heap.md
+++ b/algorithm/is_heap.md
@@ -1,6 +1,6 @@
 # is_heap
 
-**Description :** The C++ function `std::is_heap` returns `true` if the elements in the range `[first, last)` form a _max heap_, such as is constructed by _make_heap_, and `false` otherwise.
+**Description :** The C++ function `std::is_heap` returns `true` if the elements in the range `[first, last]` form a _max heap_, such as is constructed by _make_heap_, and `false` otherwise.
 
 **Example :**
 


### PR DESCRIPTION
<!-- short description of your changes -->
This PR... changes one bracket to match with another

<!-- Add issue no which corresponds to this PR -->
~~Fixes #~~ No issue opened

## Changes
<!-- go verbose here & explain what you changed -->
- Changed `)` to `]` to match with `[` in `algorithm/is_heap.md`

## Checklist
- [x] I have read CONTRIBUTING guidelines.
- [x] This is a typo fix.
- [x] I am not updating any `todo.txt` files.
