### PR TITLE
Add std::deque snippets

### DIFF
--- a/snippets/deque/Makefile
+++ b/snippets/deque/Makefile
@@ -1,0 +1,17 @@
+SRC_PATH=.
+OUT_PATH=./bin
+SRC_FILES:=$(wildcard ${SRC_PATH}/*.cpp)
+SRC_FILES:= $(filter-out ${SRC_PATH}/sample.cpp, $(SRC_FILES))
+SRC_BIN=$(SRC_FILES:${SRC_PATH}/%.cpp=${OUT_PATH}/%)
+
+CXX=g++
+
+all: $(SRC_BIN)
+
+${OUT_PATH}/%: ${SRC_PATH}/%.cpp
+	mkdir -p ${OUT_PATH}
+	${CXX} -std=c++17 $^ -o $@
+clean:
+	@rm -rf ${OUT_PATH}
+
+

--- a/snippets/deque/at.cpp
+++ b/snippets/deque/at.cpp
@@ -1,0 +1,23 @@
+/*
+    Author : Karina Murawko-Wisniewska
+    Date : Date format 07/12/2022
+    Time : Time format 11:37
+    Description : std::deque::at() returns a refernce to the element at position
+                  passed as  paramter
+*/
+
+#include <iostream>
+#include <deque>
+
+int main() {
+    std::deque<std::string> sampleDeque{"Alice", "Bob", "John"};
+    int position{1};
+
+    // Print element in position 1 (positions are numbered from 0)
+    std::cout << "Element in position " << position << ": "
+              << sampleDeque.at(position) << ".\n";
+
+    // output: Element in position 1: Bob.
+
+    return 0;
+}

--- a/snippets/deque/empty.cpp
+++ b/snippets/deque/empty.cpp
@@ -1,0 +1,24 @@
+/*
+    Author : Karina Murawko-Wisniewska
+    Date : Date format 07/12/2022
+    Time : Time format 11:45
+    Description : std::deque::empty() returns true if container is empty
+*/
+
+#include <deque>
+#include <iostream>
+
+int main() {
+    std::deque<std::string> sampleDeque{"Alice", "Bob", "John"};
+
+    // Check if sampleDeque is empty
+    if (sampleDeque.empty()) {
+        std::cout << "sampleDeque is empty.\n";
+    } else {
+        std::cout << "sampleDeque is not empty.\n";
+    }
+
+    // output: sampleDeque is not empty.
+
+    return 0;
+}

--- a/snippets/deque/push_back.cpp
+++ b/snippets/deque/push_back.cpp
@@ -1,0 +1,28 @@
+/*
+    Author : Karina Murawko-Wisniewska
+    Date : Date format 07/12/2022
+    Time : Time format 11:37
+    Description : std::deque::push_back() push element at the end of the deque
+*/
+
+#include <iostream>
+#include <deque>
+
+int main() {
+    std::deque<std::string> sampleDeque{"Alice"};
+
+    // push 2 elements at the end of sampleDeque
+    sampleDeque.push_back("Bob");
+    sampleDeque.push_back("John");
+
+    // Print elements in sampleDeque
+    std::cout << "Elements in sampleDeque: ";
+    for (auto element : sampleDeque) {
+        std::cout << element << ", ";
+    }
+    std::cout << "\n";
+
+    // output: Elements in sampleDeque: Alice, Bob, John,
+
+    return 0;
+}

--- a/snippets/deque/push_front.cpp
+++ b/snippets/deque/push_front.cpp
@@ -1,0 +1,29 @@
+/*
+    Author : Karina Murawko-Wisniewska
+    Date : Date format 07/12/2022
+    Time : Time format 12:17
+    Description : std::deque::push_front() push element at the beginning of the
+   deque
+*/
+
+#include <iostream>
+#include <deque>
+
+int main() {
+    std::deque<std::string> sampleDeque{"John"};
+
+    // push 2 elements at the beginning of sampleDeque
+    sampleDeque.push_front("Bob");
+    sampleDeque.push_front("Alice");
+
+    // Print elements in sampleDeque
+    std::cout << "Elements in sampleDeque: ";
+    for (auto element : sampleDeque) {
+        std::cout << element << ", ";
+    }
+    std::cout << "\n";
+
+    // output: Elements in sampleDeque: Alice, Bob, John,
+
+    return 0;
+}

--- a/snippets/deque/sample.cpp
+++ b/snippets/deque/sample.cpp
@@ -1,0 +1,8 @@
+// Follow the Style Guide while submitting code PR.
+// Style Guide => https://github.com/Bhupesh-V/30-Seconds-Of-STL/blob/master/CONTRIBUTING.md/#Style Guide
+/*
+    Author : this must be your name ;)
+    Date : Date format dd/mm/yyyy
+    Time : Time format hh:mm
+    Description : description should be small & one liner.
+*/

--- a/snippets/deque/size.cpp
+++ b/snippets/deque/size.cpp
@@ -1,0 +1,20 @@
+/*
+    Author : Karina Murawko-Wisniewska
+    Date : Date format 07/12/2022
+    Time : Time format 11:53
+    Description : std::deque::size() returns number of elements
+*/
+
+#include <deque>
+#include <iostream>
+
+int main() {
+    std::deque<std::string> sampleDeque{"Alice", "Bob", "John"};
+
+    // Print number of elements of sampleDeque
+    std::cout << "sampleDeque has " << sampleDeque.size() << " elements.\n";
+
+    // output: sampleDeque has 3 elements.
+
+    return 0;
+}


### PR DESCRIPTION
Add std::deque snippets: at, size, empty, push_back, push_front.

## Changes
Double-ended queue std::deque is not present in snippets. Added following snippets: at, size, empty, push_back, push_front.

## Checklist
- [x] I have read CONTRIBUTING guidelines.
- [ ] This is a typo fix.
- [x] I am not updating any `todo.txt` files.
